### PR TITLE
マテリアルアイコンの本番環境とローカル環境のcssの違いを修正した

### DIFF
--- a/styles/home/home.module.scss
+++ b/styles/home/home.module.scss
@@ -94,12 +94,12 @@
 
 //チャンネルの選択テキスト
 
-.open_sidebar {
-  display: none;
-}
-
 .select_channel_text {
   position: relative;
+
+  .open_sidebar {
+    display: none;
+  }
 
   h1 {
     position: absolute;


### PR DESCRIPTION
matarial-iconにサス記法でcssを当てるとcssが喧嘩してしまってうまく表示されなかったので、そのエラーを解決した。